### PR TITLE
fix: Correct stop-on-failure flag name

### DIFF
--- a/conformance_test.go
+++ b/conformance_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 
 	flag.StringVar(&godogFormat, "format", "pretty", "Set godog format to use. Valid values are pretty and cucumber")
 	flag.StringVar(&godogTags, "tags", "", "Tags for conformance test")
-	flag.BoolVar(&godogStopOnFailure, "stop-on-failure ", false, "Stop when failure is found")
+	flag.BoolVar(&godogStopOnFailure, "stop-on-failure", false, "Stop when failure is found")
 	flag.BoolVar(&godogNoColors, "no-colors", false, "Disable colors in godog output")
 	flag.StringVar(&godogOutput, "output-directory", ".", "Output directory for test reports")
 	flag.StringVar(&kubernetes.IngressClassValue, "ingress-class", "conformance", "Sets the value of the annotation kubernetes.io/ingress.class in Ingress definitions")


### PR DESCRIPTION
There is extra space at the end, which makes the flag un-usable.