### PR TITLE
test: Use multi-arch echoserver image

### DIFF
--- a/test/kubernetes/deployment.go
+++ b/test/kubernetes/deployment.go
@@ -38,7 +38,7 @@ import (
 const EchoService = "echo"
 
 // EchoContainer container image name
-const EchoContainer = "k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52"
+const EchoContainer = "gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e"
 
 // NewEchoDeployment creates a new deployment of the echoserver image in a particular namespace.
 func NewEchoDeployment(kubeClientSet kubernetes.Interface, namespace, name, serviceName, servicePortName string, servicePort int32) error {


### PR DESCRIPTION
Use multi-arch (amd64, arm64) echoserver image so that testing works also on arm (e.g., M-series Macs).

This same image is already used in `cilium/cilium` via https://github.com/cilium/cilium/pull/37267