### PR TITLE
test: Only delete namespaces of successful tests

### DIFF
--- a/hack/codegen.tmpl
+++ b/hack/codegen.tmpl
@@ -39,9 +39,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) { {{- range .NewFunctions }}
 		state = tstate.New()
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 {{ range .NewFunctions }}

--- a/test/conformance/defaultbackend/feature.go
+++ b/test/conformance/defaultbackend/feature.go
@@ -52,9 +52,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		state = tstate.New()
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 

--- a/test/conformance/hostrules/feature.go
+++ b/test/conformance/hostrules/feature.go
@@ -49,9 +49,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		state = tstate.New()
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 

--- a/test/conformance/ingressclass/feature.go
+++ b/test/conformance/ingressclass/feature.go
@@ -42,9 +42,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		state = tstate.New()
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 

--- a/test/conformance/loadbalancing/feature.go
+++ b/test/conformance/loadbalancing/feature.go
@@ -52,9 +52,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		resultStatus = make(map[int]sets.String, 0)
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 

--- a/test/conformance/pathrules/feature.go
+++ b/test/conformance/pathrules/feature.go
@@ -46,9 +46,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		state = tstate.New()
 	})
 
-	ctx.AfterScenario(func(*messages.Pickle, error) {
-		// delete namespace an all the content
-		_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+	ctx.AfterScenario(func(_ *messages.Pickle, err error) {
+		// delete namespace and all the content only if there was no failure
+		if err == nil {
+			_ = kubernetes.DeleteNamespace(kubernetes.KubeClient, state.Namespace)
+		}
 	})
 }
 


### PR DESCRIPTION
Leave the test namespace around for failed tests to make debugging easier.